### PR TITLE
Fix enum generator and integrate lookup enums

### DIFF
--- a/client/src/features/attendance/Attendance.tsx
+++ b/client/src/features/attendance/Attendance.tsx
@@ -11,7 +11,7 @@ import type {
   AttendanceList,
 } from "@shared/validation";
 import type { ApiResult } from "@/types/apiTypes";
-import { Present } from "@shared/types";
+import { AttendanceStatus } from "@shared/types";
 
 import AttendanceTable from "./AttendanceTable";
 import { AttendanceButtons, AttendanceFilters } from "./AttendanceControls";
@@ -19,7 +19,7 @@ import { AttendanceButtons, AttendanceFilters } from "./AttendanceControls";
 type AttendanceUi = {
   data: Attendance;
   isDirty: boolean;
-  original: Present;
+  original: AttendanceStatus;
 };
 
 export default function Attendance() {
@@ -46,7 +46,7 @@ export default function Attendance() {
 
     setAttendance(
       result.data.map((entry) => {
-        const present = entry.present ?? Present.NotScheduled;
+        const present = entry.present ?? AttendanceStatus.NotScheduled;
         return {
           data: { ...entry, present },
           original: present,
@@ -63,7 +63,7 @@ export default function Attendance() {
     void fetchAttendance();
   }, [date, side]);
 
-  const onPresentChange = (cid: number, val: Present) => {
+  const onPresentChange = (cid: number, val: AttendanceStatus) => {
     setAttendance((prev) =>
       prev.map((entry) =>
         entry.data.cid === cid

--- a/client/src/features/attendance/AttendanceTable.tsx
+++ b/client/src/features/attendance/AttendanceTable.tsx
@@ -10,14 +10,14 @@ import {
 } from "@/components/ui/table";
 
 import { cn } from "@/lib/utils";
-import { Present } from "@shared/types";
+import { AttendanceStatus } from "@shared/types";
 import type { Attendance } from "@shared/validation";
 import type { AttendanceUi } from "./Attendance";
 
 type Props = {
   data: AttendanceUi[];
   edit: boolean;
-  onPresentChange: (cid: number, val: Present) => void;
+  onPresentChange: (cid: number, val: AttendanceStatus) => void;
 };
 
 export default function AttendanceTable({
@@ -25,10 +25,10 @@ export default function AttendanceTable({
   edit,
   onPresentChange,
 }: Props) {
-  const bgColorMap: Record<Present, string> = {
-    [Present.Here]: "bg-[var(--attendance-present-bg)]",
-    [Present.Absent]: "bg-[var(--attendance-absent-bg)]",
-    [Present.NotScheduled]: "bg-[var(--attendance-not-scheduled-bg)]",
+  const bgColorMap: Record<AttendanceStatus, string> = {
+    [AttendanceStatus.Present]: "bg-[var(--attendance-present-bg)]",
+    [AttendanceStatus.Absent]: "bg-[var(--attendance-absent-bg)]",
+    [AttendanceStatus.NotScheduled]: "bg-[var(--attendance-not-scheduled-bg)]",
   };
 
   return (
@@ -49,7 +49,7 @@ export default function AttendanceTable({
                 {row.data.lname}, {row.data.fname}
               </TableCell>
 
-              {[Present.Here, Present.Absent, Present.NotScheduled].map(
+              {[AttendanceStatus.Present, AttendanceStatus.Absent, AttendanceStatus.NotScheduled].map(
                 (val) => (
                   <TableCell
                     key={val}
@@ -68,9 +68,9 @@ export default function AttendanceTable({
                   >
                     {row.data.present === val && (
                       <div className="flex flex-col items-center justify-center gap-2">
-                        {val === Present.Here && <CheckCircle />}
-                        {val === Present.Absent && <XCircle />}
-                        {val === Present.NotScheduled && <PauseCircle />}
+                        {val === AttendanceStatus.Present && <CheckCircle />}
+                        {val === AttendanceStatus.Absent && <XCircle />}
+                        {val === AttendanceStatus.NotScheduled && <PauseCircle />}
                         <span className="text-[9px] sm:text-sm">{val}</span>
                       </div>
                     )}

--- a/server/src/controllers/attendance.controller.ts
+++ b/server/src/controllers/attendance.controller.ts
@@ -2,13 +2,13 @@ import {
   getAttendanceService,
   upsertAttendanceService,
 } from "@/services/attendance.service";
-import { type AttendanceQuery, type AttendanceList } from "@shared/types";
+import { type AttendaneQuery, type AttendanceList } from "@shared/validation";
 import { type ServiceResponse } from "@/types/server.types";
 import { isServiceSuccess } from "@/utils/controller.util";
-import { Side } from "@shared/generated/types/side.enum";
+import { Side } from "@shared/types";
 
 export async function getAttendance(req, res) {
-  const query: AttendanceQuery = req.validatedQuery;
+  const query: AttendaneQuery = req.validatedQuery;
   const userSide = req.user.side;
   const requestedSide = query.side;
 

--- a/server/src/generate_enums.ts
+++ b/server/src/generate_enums.ts
@@ -15,13 +15,14 @@ const toEnumKey = (c: string) =>
     .replace(/([a-z])([A-Z])/g, "$1_$2")
     .toUpperCase();
 
-const toEnumName = (t: string) =>
-  t
-    .replace(/ses$/, "s")
-    .replace(/s$/, "")
+const toEnumName = (t: string) => {
+  if (t.endsWith("ses")) t = t.slice(0, -2);
+  else if (t.endsWith("s")) t = t.slice(0, -1);
+  return t
     .split("_")
     .map((p) => p[0].toUpperCase() + p.slice(1))
     .join("");
+};
 
 const generateEnumSet = (enumName: string, rows: any[], columns: string[]) => {
   const enums = rows

--- a/server/src/lookup.config.ts
+++ b/server/src/lookup.config.ts
@@ -1,32 +1,7 @@
-export const LookupRegistry = {
-  Role: {
-    table: "roles",
-    codeToEnum: CodeToRole,
-    idToEnum: IdToRole,
-    details: RoleDetails,
-  },
-  Status: {
-    table: "statuses",
-    codeToEnum: CodeToStatus,
-    idToEnum: IdToStatus,
-    details: StatusDetails,
-  },
-  Side: {
-    table: "sides",
-    codeToEnum: CodeToSide,
-    idToEnum: IdToSide,
-    details: SideDetails,
-  },
-  AttendanceStatus: {
-    table: "attendance_statuses",
-    codeToEnum: CodeToAttendanceStatus,
-    idToEnum: IdToAttendanceStatus,
-    details: AttendanceStatusDetails,
-  },
-  PromptLevel: {
-    table: "prompt_levels",
-    codeToEnum: CodeToPromptLevel,
-    idToEnum: IdToPromptLevel,
-    details: PromptLevelDetails,
-  },
-} as const;
+export const LOOKUP_CONFIG = [
+  { table: "roles", columns: ["id", "code", "label", "level"] },
+  { table: "sides", columns: ["id", "code", "label"] },
+  { table: "statuses", columns: ["id", "code", "label"] },
+  { table: "attendance_statuses", columns: ["id", "code", "label"] },
+  { table: "prompt_levels", columns: ["id", "code", "label"] },
+] as const;

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 
-import { Role, RoleLevel } from "@shared/types";
+import { Role } from "@shared/types";
 import { hasRequiredRole } from "@shared/utils";
 import { getUserService } from "@/services/user.service";
 

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -46,7 +46,7 @@ import {
   usernameSchema,
 } from "@shared/validation";
 
-import { Role } from "@shared/generated/lookup.types";
+import { Role } from "@shared/types";
 
 const router = express.Router();
 

--- a/server/src/services/client.service.ts
+++ b/server/src/services/client.service.ts
@@ -6,7 +6,12 @@ import type {
   SerialId,
 } from "@shared/validation";
 import type { ServiceResponse } from "@/types/server.types";
-import { createSuccess, createFail } from "@/utils/service.util";
+import {
+  createSuccess,
+  createFail,
+  getCodeById,
+  getIdByCode,
+} from "@/utils/service.util";
 import { Status } from "@shared/types";
 
 export async function getClientService(
@@ -14,14 +19,20 @@ export async function getClientService(
 ): Promise<ServiceResponse<Client>> {
   const pool = await getPool();
   const result = await pool.query(
-    `SELECT id, fname, lname, side, status FROM clients WHERE id = $1`,
+    `SELECT id, fname, lname, side_id, status_id FROM clients WHERE id = $1`,
     [id]
   );
   const client = result.rows[0];
   if (!client) {
     return createFail({ status: 404, message: "Client not found" });
   }
-  return createSuccess({ data: client });
+  return createSuccess({
+    data: {
+      ...client,
+      side: await getCodeById("side", client.side_id),
+      status: await getCodeById("status", client.status_id),
+    },
+  });
 }
 
 export async function getClientsService(): Promise<
@@ -29,9 +40,15 @@ export async function getClientsService(): Promise<
 > {
   const pool = await getPool();
   const result = await pool.query(
-    `SELECT id, fname, lname, side, status FROM clients`
+    `SELECT id, fname, lname, side_id, status_id FROM clients`
   );
-  const clientList: ClientList = result.rows ?? [];
+  const clientList: ClientList = await Promise.all(
+    result.rows.map(async (c) => ({
+      ...c,
+      side: await getCodeById("side", c.side_id),
+      status: await getCodeById("status", c.status_id),
+    }))
+  );
   return createSuccess({ data: clientList });
 }
 
@@ -41,8 +58,14 @@ export async function updateClientService(
 ): Promise<ServiceResponse<undefined>> {
   const pool = await getPool();
   const result = await pool.query(
-    `UPDATE clients SET fname = $1, lname = $2, side = $3, status = $4 WHERE id = $5`,
-    [fname, lname, side, status, id]
+    `UPDATE clients SET fname = $1, lname = $2, side_id = $3, status_id = $4 WHERE id = $5`,
+    [
+      fname,
+      lname,
+      await getIdByCode("side", side),
+      await getIdByCode("status", status),
+      id,
+    ]
   );
   if (result.rowCount === 0) {
     return createFail({ status: 404, message: "Client not found" });
@@ -55,8 +78,8 @@ export async function deactivateClientsService(
 ): Promise<ServiceResponse<undefined>> {
   const pool = await getPool();
   const result = await pool.query(
-    `UPDATE clients SET status = $1 WHERE id = ANY($2)`,
-    [Status.Deactivated, ids]
+    `UPDATE clients SET status_id = $1 WHERE id = ANY($2)`,
+    [await getIdByCode("status", Status.Deactivated), ids]
   );
   if (result.rowCount === 0) {
     return createFail({
@@ -103,10 +126,15 @@ export async function createClientService({
   try {
     await client.query("BEGIN");
     const insertClientResult = await client.query(
-      `INSERT INTO clients (fname, lname, side, status)
+      `INSERT INTO clients (fname, lname, side_id, status_id)
        VALUES ($1, $2, $3, $4)
        RETURNING id`,
-      [fname, lname, side, status]
+      [
+        fname,
+        lname,
+        await getIdByCode("side", side),
+        await getIdByCode("status", status),
+      ]
     );
     const cid = insertClientResult.rows[0]?.id;
     if (!cid) {

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -19,7 +19,7 @@ import {
   getCodeById,
 } from "@/utils/service.util";
 import config from "@/config";
-import { Role } from "@shared/generated/lookup.types";
+import { Role } from "@shared/types";
 
 const cognitoClient = new CognitoIdentityProviderClient({
   region: config.cognito.region,

--- a/server/src/utils/service.util.ts
+++ b/server/src/utils/service.util.ts
@@ -1,5 +1,21 @@
 import { type ServiceSuccess, type ServiceFail } from "@/types/server.types";
-import { RoleDetails } from "@shared/generated/lookup.types";
+import {
+  CodeToRole,
+  IdToRole,
+  RoleDetails,
+  CodeToStatus,
+  IdToStatus,
+  StatusDetails,
+  CodeToAttendanceStatus,
+  IdToAttendanceStatus,
+  AttendanceStatusDetails,
+  CodeToSide,
+  IdToSide,
+  SideDetails,
+  CodeToPromptLevel,
+  IdToPromptLevel,
+  PromptLevelDetails,
+} from "@shared/types";
 
 export function createSuccess<T>({
   status = 200,
@@ -63,7 +79,7 @@ const EnumMaps = {
   },
 } as const;
 
-async function getIdByCode(
+export async function getIdByCode(
   table: keyof typeof EnumMaps,
   code: string
 ): Promise<number> {
@@ -73,7 +89,7 @@ async function getIdByCode(
   return details[enumVal].id;
 }
 
-async function getCodeById(
+export async function getCodeById(
   table: keyof typeof EnumMaps,
   id: number
 ): Promise<string> {

--- a/shared/src/generated/lookup.types.ts
+++ b/shared/src/generated/lookup.types.ts
@@ -45,48 +45,48 @@ export const SideDetails: Record<Side, { id: number; code: string; label: string
   [Side.TWO]: { id: 2, code: "two", label: "ADE TOO!" },
 };
 
-export enum Statu {
+export enum Status {
   ACTIVE = "active",
   DEACTIVATED = "deactivated",
 }
 
-export const CodeToStatu: Record<string, Statu> = {
-  "active": Statu.ACTIVE,
-  "deactivated": Statu.DEACTIVATED,
+export const CodeToStatus: Record<string, Status> = {
+  "active": Status.ACTIVE,
+  "deactivated": Status.DEACTIVATED,
 };
 
-export const IdToStatu: Record<number, Statu> = {
-  1: Statu.ACTIVE,
-  2: Statu.DEACTIVATED,
+export const IdToStatus: Record<number, Status> = {
+  1: Status.ACTIVE,
+  2: Status.DEACTIVATED,
 };
 
-export const StatuDetails: Record<Statu, { id: number; code: string; label: string }> = {
-  [Statu.ACTIVE]: { id: 1, code: "active", label: "Active" },
-  [Statu.DEACTIVATED]: { id: 2, code: "deactivated", label: "Deactivated" },
+export const StatusDetails: Record<Status, { id: number; code: string; label: string }> = {
+  [Status.ACTIVE]: { id: 1, code: "active", label: "Active" },
+  [Status.DEACTIVATED]: { id: 2, code: "deactivated", label: "Deactivated" },
 };
 
-export enum AttendanceStatu {
+export enum AttendanceStatus {
   ABSENT = "absent",
   NOT_SCHEDULED = "not_scheduled",
   PRESENT = "present",
 }
 
-export const CodeToAttendanceStatu: Record<string, AttendanceStatu> = {
-  "absent": AttendanceStatu.ABSENT,
-  "not_scheduled": AttendanceStatu.NOT_SCHEDULED,
-  "present": AttendanceStatu.PRESENT,
+export const CodeToAttendanceStatus: Record<string, AttendanceStatus> = {
+  "absent": AttendanceStatus.ABSENT,
+  "not_scheduled": AttendanceStatus.NOT_SCHEDULED,
+  "present": AttendanceStatus.PRESENT,
 };
 
-export const IdToAttendanceStatu: Record<number, AttendanceStatu> = {
-  2: AttendanceStatu.ABSENT,
-  3: AttendanceStatu.NOT_SCHEDULED,
-  1: AttendanceStatu.PRESENT,
+export const IdToAttendanceStatus: Record<number, AttendanceStatus> = {
+  2: AttendanceStatus.ABSENT,
+  3: AttendanceStatus.NOT_SCHEDULED,
+  1: AttendanceStatus.PRESENT,
 };
 
-export const AttendanceStatuDetails: Record<AttendanceStatu, { id: number; code: string; label: string }> = {
-  [AttendanceStatu.ABSENT]: { id: 2, code: "absent", label: "Absent" },
-  [AttendanceStatu.NOT_SCHEDULED]: { id: 3, code: "not_scheduled", label: "Not Scheduled" },
-  [AttendanceStatu.PRESENT]: { id: 1, code: "present", label: "Present" },
+export const AttendanceStatusDetails: Record<AttendanceStatus, { id: number; code: string; label: string }> = {
+  [AttendanceStatus.ABSENT]: { id: 2, code: "absent", label: "Absent" },
+  [AttendanceStatus.NOT_SCHEDULED]: { id: 3, code: "not_scheduled", label: "Not Scheduled" },
+  [AttendanceStatus.PRESENT]: { id: 1, code: "present", label: "Present" },
 };
 
 export enum PromptLevel {
@@ -132,7 +132,7 @@ export const PromptLevelDetails: Record<PromptLevel, { id: number; code: string;
 export const LookupRegistry = {
   roles: { table: "roles", codeToEnum: CodeToRole, idToEnum: IdToRole, details: RoleDetails },
   sides: { table: "sides", codeToEnum: CodeToSide, idToEnum: IdToSide, details: SideDetails },
-  statuses: { table: "statuses", codeToEnum: CodeToStatu, idToEnum: IdToStatu, details: StatuDetails },
-  attendance_statuses: { table: "attendance_statuses", codeToEnum: CodeToAttendanceStatu, idToEnum: IdToAttendanceStatu, details: AttendanceStatuDetails },
+  statuses: { table: "statuses", codeToEnum: CodeToStatus, idToEnum: IdToStatus, details: StatusDetails },
+  attendance_statuses: { table: "attendance_statuses", codeToEnum: CodeToAttendanceStatus, idToEnum: IdToAttendanceStatus, details: AttendanceStatusDetails },
   prompt_levels: { table: "prompt_levels", codeToEnum: CodeToPromptLevel, idToEnum: IdToPromptLevel, details: PromptLevelDetails },
 } as const;

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,0 +1,1 @@
+export * from "./generated/lookup.types";

--- a/shared/src/validation.ts
+++ b/shared/src/validation.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Role, Present, Status, Side } from "./generated/lookup.types";
+import { Role, AttendanceStatus, Status, Side } from "./generated/lookup.types";
 import { format } from "date-fns";
 
 const _ = {
@@ -41,7 +41,8 @@ const _ = {
   side: z.nativeEnum(Side, {
     errorMap: () => ({ message: "Side is required" }),
   }),
-  attendance_status: z.nativeEnum(Present),
+  attendance_status: z.nativeEnum(AttendanceStatus),
+  present: z.nativeEnum(AttendanceStatus),
   status: z.nativeEnum(Status, {
     errorMap: () => ({ message: "Status is required" }),
   }),
@@ -50,7 +51,7 @@ const _ = {
 export const lookupsSchema = z.object({
   role: _.role,
   side: _.side,
-  attendance_status: _.attendance_satus,
+  attendance_status: _.attendance_status,
   status: _.status,
 });
 export type Lookups = z.infer<typeof lookupsSchema>;


### PR DESCRIPTION
## Summary
- rewrite enum generator helper and add lookup config
- export helper functions for enum ID lookups
- rework auth, client, and attendance services to use lookup tables
- update validation and client attendance features to use `AttendanceStatus`
- provide aggregated types from generated enums

## Testing
- `npx tsc -p server/tsconfig.json` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68716d6aa5e08330a5d148d2ce4b3147