### PR TITLE
Restore side handling

### DIFF
--- a/server/sql/create-tables.ts
+++ b/server/sql/create-tables.ts
@@ -1,6 +1,6 @@
 // create-tables.ts – schema using enums for CHECK constraints
 import { getPool } from "@/db";
-import { AttendanceStatus, Role, Status } from "@shared/types";
+import { AttendanceStatus, Role, Status, Side } from "@shared/types";
 
 const pool = await getPool();
 
@@ -18,12 +18,14 @@ const attendanceStatusCheck = enumCheck(
 );
 const roleCheck = enumCheck("role", Object.values(Role));
 const statusCheck = enumCheck("status", Object.values(Status));
+const sideCheck = enumCheck("side", Object.values(Side));
 
 await pool.query(`
   CREATE TABLE IF NOT EXISTS clients (
     id SERIAL PRIMARY KEY,
     fname TEXT NOT NULL,
     lname TEXT NOT NULL,
+    side TEXT NOT NULL ${sideCheck},
     status TEXT NOT NULL ${statusCheck}
   );
 
@@ -32,6 +34,7 @@ await pool.query(`
     fname TEXT NOT NULL,
     lname TEXT NOT NULL,
     username TEXT NOT NULL UNIQUE,
+    side TEXT NOT NULL ${sideCheck},
     role TEXT NOT NULL ${roleCheck},
     status TEXT NOT NULL ${statusCheck}
   );

--- a/server/sql/reset-db.ts
+++ b/server/sql/reset-db.ts
@@ -11,7 +11,7 @@ import {
 
 import { getPool } from "@/db";
 import config from "@/config";
-import { AttendanceStatus, Status, Role } from "@shared/types";
+import { AttendanceStatus, Status, Role, Side } from "@shared/types";
 import { registerService } from "@/services/auth.service";
 
 // -----------------------------------------------------------------------------
@@ -87,6 +87,7 @@ function enumCheck(column: string, values: string[]): string {
   );
   const roleCheck = enumCheck("role", Object.values(Role));
   const statusCheck = enumCheck("status", Object.values(Status));
+  const sideCheck = enumCheck("side", Object.values(Side));
 
   await pool.query(`
     CREATE TABLE users (
@@ -94,6 +95,7 @@ function enumCheck(column: string, values: string[]): string {
       fname TEXT NOT NULL,
       lname TEXT NOT NULL,
       username TEXT NOT NULL UNIQUE,
+      side TEXT NOT NULL ${sideCheck},
       role TEXT NOT NULL ${roleCheck},
       status TEXT NOT NULL ${statusCheck}
     );
@@ -102,6 +104,7 @@ function enumCheck(column: string, values: string[]): string {
       id SERIAL PRIMARY KEY,
       fname TEXT NOT NULL,
       lname TEXT NOT NULL,
+      side TEXT NOT NULL ${sideCheck},
       status TEXT NOT NULL ${statusCheck}
     );
 
@@ -155,6 +158,7 @@ function enumCheck(column: string, values: string[]): string {
   // 4. Seeding helpers & data
   // ────────────────────────────────────────
   const statusValues = Object.values(Status) as Status[];
+  const sideValues = Object.values(Side) as Side[];
   const attendanceStatusValues = Object.values(
     AttendanceStatus
   ) as AttendanceStatus[];
@@ -180,8 +184,8 @@ function enumCheck(column: string, values: string[]): string {
 
     for (const [fname, lname] of names) {
       await pool.query(
-        `INSERT INTO clients (fname, lname, status) VALUES ($1,$2,$3) ON CONFLICT DO NOTHING`,
-        [fname, lname, rand(statusValues)]
+        `INSERT INTO clients (fname, lname, side, status) VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING`,
+        [fname, lname, rand(sideValues), rand(statusValues)]
       );
     }
 
@@ -306,6 +310,7 @@ function enumCheck(column: string, values: string[]): string {
     username: "admin",
     fname: "Admin",
     lname: "User",
+    side: Side.Both,
     role: Role.Admin,
     status: Status.Active,
   } as any); // cast to satisfy Service typing

--- a/server/sql/seed.ts
+++ b/server/sql/seed.ts
@@ -1,7 +1,7 @@
 // seed.ts
 
 import { getPool } from "@/db";
-import { AttendanceStatus, Status } from "@shared/types";
+import { AttendanceStatus, Status, Side } from "@shared/types";
 import { subDays, formatISO } from "date-fns";
 
 const pool = await getPool();
@@ -15,6 +15,7 @@ const rand = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
 const log = (msg: string) => console.log("✅", msg);
 
 const statusValues = Object.values(Status) as Status[];
+const sideValues = Object.values(Side) as Side[];
 const attendanceStatusValues = Object.values(
   AttendanceStatus
 ) as AttendanceStatus[];
@@ -35,11 +36,12 @@ async function seedClients() {
 
   for (const [fname, lname] of names) {
     const status = rand(statusValues);
+    const side = rand(sideValues);
     await pool.query(
-      `INSERT INTO clients (fname, lname, status)
-       VALUES ($1, $2, $3)
+      `INSERT INTO clients (fname, lname, side, status)
+       VALUES ($1, $2, $3, $4)
        ON CONFLICT DO NOTHING`,
-      [fname, lname, status]
+      [fname, lname, side, status]
     );
   }
 

--- a/server/src/services/attendance.service.ts
+++ b/server/src/services/attendance.service.ts
@@ -9,9 +9,10 @@ import { createSuccess, createFail } from "@/utils/service.util";
 
 export async function getAttendanceService({
   date,
+  side,
 }: AttendanceQuery): Promise<ServiceResponse<AttendanceList>> {
   const pool = await getPool();
-  const params = [date];
+  const params = [date, side];
 
   const query = `
     SELECT
@@ -27,6 +28,7 @@ export async function getAttendanceService({
     AND attendance.attendance_date = $1
     WHERE client_roster.start_date <= $1
       AND (client_roster.end_date IS NULL OR client_roster.end_date >= $1)
+      AND clients.side = $2
     ORDER BY clients.lname
   `;
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -8,7 +8,7 @@ import {
 
 import { getPool } from "@/db";
 import config from "@/config";
-import { Status } from "@shared/types";
+import { Status, Side } from "@shared/types";
 import type { Credentials, AuthResult, UserData } from "@shared/validation";
 import { createUserService } from "@/services/user.service";
 import { type ServiceResponse } from "@/types/server.types";
@@ -70,7 +70,7 @@ export async function loginService({
   const pool = await getPool();
   const result = await pool.query(
     `
-      SELECT id, fname, lname, username, role, status
+      SELECT id, fname, lname, username, side, role, status
       FROM users
       WHERE username = $1
     `,
@@ -118,7 +118,7 @@ export async function completeChallengeService(
 export async function registerService(
   userData: UserData
 ): Promise<ServiceResponse<undefined>> {
-  const { username, fname, lname, role, status } = userData;
+  const { username, fname, lname, side, role, status } = userData;
   const pool = await getPool();
   const client = await pool.connect();
 
@@ -126,9 +126,9 @@ export async function registerService(
     await client.query("BEGIN");
 
     await client.query(
-      `INSERT INTO users (username, fname, lname, role, status)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [username, fname, lname, role, status]
+      `INSERT INTO users (username, fname, lname, side, role, status)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [username, fname, lname, side, role, status]
     );
 
     const createCommand = new AdminCreateUserCommand({

--- a/server/src/services/client.service.ts
+++ b/server/src/services/client.service.ts
@@ -14,7 +14,7 @@ export async function getClientService(
   const pool = await getPool();
 
   const query = `
-    SELECT id, fname, lname, status
+    SELECT id, fname, lname, side, status
     FROM clients
     WHERE id = $1
   `;
@@ -35,7 +35,7 @@ export async function getClientsService(): Promise<
   const pool = await getPool();
 
   const query = `
-    SELECT id, fname, lname, status
+    SELECT id, fname, lname, side, status
     FROM clients
   `;
   const result = await pool.query(query);
@@ -46,15 +46,15 @@ export async function getClientsService(): Promise<
 
 export async function updateClientService(
   id: SerialId,
-  { fname, lname, status }: ClientData
+  { fname, lname, side, status }: ClientData
 ): Promise<ServiceResponse<undefined>> {
   const pool = await getPool();
 
   const result = await pool.query(
     `UPDATE clients
-     SET fname = $1, lname = $2, status = $3
-     WHERE id = $4`,
-    [fname, lname, status, id]
+     SET fname = $1, lname = $2, side = $3, status = $4
+     WHERE id = $5`,
+    [fname, lname, side, status, id]
   );
 
   if (result.rowCount === 0) {
@@ -67,6 +67,7 @@ export async function updateClientService(
 export async function createClientService({
   fname,
   lname,
+  side,
   status,
 }: ClientData): Promise<ServiceResponse<undefined>> {
   const pool = await getPool();
@@ -76,10 +77,10 @@ export async function createClientService({
     await client.query("BEGIN");
 
     const insertClientResult = await client.query(
-      `INSERT INTO clients (fname, lname, status)
-       VALUES ($1, $2, $3)
+      `INSERT INTO clients (fname, lname, side, status)
+       VALUES ($1, $2, $3, $4)
        RETURNING id`,
-      [fname, lname, status]
+      [fname, lname, side, status]
     );
 
     const cid = insertClientResult.rows[0]?.id;

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -11,7 +11,7 @@ import type {
 } from "@shared/validation";
 import type { ServiceResponse } from "@/types/server.types";
 import { createSuccess, createFail } from "@/utils/service.util";
-import { Status } from "@shared/types";
+import { Status, Side } from "@shared/types";
 import config from "@/config";
 
 const cognitoClient = new CognitoIdentityProviderClient({
@@ -24,7 +24,7 @@ export async function getUserService(
   const pool = await getPool();
 
   const query = `
-    SELECT id, fname, lname, username, role, status
+    SELECT id, fname, lname, username, side, role, status
     FROM users
     WHERE id = $1
   `;
@@ -44,7 +44,7 @@ export async function getUserService(
 export async function getUsersService(): Promise<ServiceResponse<UserList>> {
   const pool = await getPool();
 
-  let query = `SELECT id, fname, lname, username, role, status FROM users`;
+  let query = `SELECT id, fname, lname, username, side, role, status FROM users`;
 
   const result = await pool.query(query);
   const userList: UserList = result.rows ?? [];
@@ -54,15 +54,15 @@ export async function getUsersService(): Promise<ServiceResponse<UserList>> {
 
 export async function updateUserService(
   id: SerialId,
-  { username, fname, lname, role, status }: UserData
+  { username, fname, lname, side, role, status }: UserData
 ): Promise<ServiceResponse<undefined>> {
   const pool = await getPool();
 
   const result = await pool.query(
     `UPDATE users
-   SET username = $1, fname = $2, lname = $3, role = $4, status = $5
-   WHERE id = $6;`,
-    [username, fname, lname, role, status, id]
+   SET username = $1, fname = $2, lname = $3, side = $4, role = $5, status = $6
+   WHERE id = $7;`,
+    [username, fname, lname, side, role, status, id]
   );
 
   if (result.rowCount === 0) {


### PR DESCRIPTION
## Summary
- bring back Side enum checks in table creation
- seed clients with side assignments
- track side in reset, user, client, and attendance services

## Testing
- `npx tsc -p tsconfig.base.json --noEmit` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_687180ffb7e483308fedfea0b20138a5