### PR TITLE
Fix remaining attendance_status uses

### DIFF
--- a/client/src/features/attendance/Attendance.tsx
+++ b/client/src/features/attendance/Attendance.tsx
@@ -46,10 +46,11 @@ export default function Attendance() {
 
     setAttendance(
       result.data.map((entry) => {
-        const present = entry.present ?? AttendanceStatus.NotScheduled;
+        const status =
+          entry.attendance_status ?? AttendanceStatus.NotScheduled;
         return {
-          data: { ...entry, present },
-          original: present,
+          data: { ...entry, attendance_status: status },
+          original: status,
           isDirty: true,
         };
       })
@@ -63,13 +64,13 @@ export default function Attendance() {
     void fetchAttendance();
   }, [date, side]);
 
-  const onPresentChange = (cid: number, val: AttendanceStatus) => {
+  const onStatusChange = (cid: number, val: AttendanceStatus) => {
     setAttendance((prev) =>
       prev.map((entry) =>
         entry.data.cid === cid
           ? {
               ...entry,
-              data: { ...entry.data, present: val },
+              data: { ...entry.data, attendance_status: val },
               isDirty: val !== entry.original,
             }
           : entry
@@ -81,7 +82,7 @@ export default function Attendance() {
     setAttendance((prev) =>
       prev.map((entry) => ({
         ...entry,
-        data: { ...entry.data, present: entry.original },
+        data: { ...entry.data, attendance_status: entry.original },
         isDirty: false,
       }))
     );
@@ -91,7 +92,7 @@ export default function Attendance() {
   const onSubmit = async () => {
     const attendanceList = attendance.map((entry) => ({
       cid: entry.data.cid,
-      present: entry.data.present,
+      attendance_status: entry.data.attendance_status,
       attendance_date: date,
     }));
 
@@ -107,7 +108,7 @@ export default function Attendance() {
     setAttendance((prev) =>
       prev.map((entry) => ({
         ...entry,
-        original: entry.data.present,
+        original: entry.data.attendance_status,
         isDirty: false,
       }))
     );
@@ -137,7 +138,7 @@ export default function Attendance() {
           <AttendanceTable
             data={filteredAttendance}
             edit={edit}
-            onPresentChange={onPresentChange}
+            onStatusChange={onStatusChange}
           />
         </div>
       </CardContent>

--- a/client/src/features/attendance/AttendanceTable.tsx
+++ b/client/src/features/attendance/AttendanceTable.tsx
@@ -17,16 +17,16 @@ import type { AttendanceUi } from "./Attendance";
 type Props = {
   data: AttendanceUi[];
   edit: boolean;
-  onPresentChange: (cid: number, val: AttendanceStatus) => void;
+  onStatusChange: (cid: number, val: AttendanceStatus) => void;
 };
 
 export default function AttendanceTable({
   data,
   edit,
-  onPresentChange,
+  onStatusChange,
 }: Props) {
   const bgColorMap: Record<AttendanceStatus, string> = {
-    [AttendanceStatus.Present]: "bg-[var(--attendance-present-bg)]",
+    [AttendanceStatus.Here]: "bg-[var(--attendance-present-bg)]",
     [AttendanceStatus.Absent]: "bg-[var(--attendance-absent-bg)]",
     [AttendanceStatus.NotScheduled]: "bg-[var(--attendance-not-scheduled-bg)]",
   };
@@ -49,26 +49,26 @@ export default function AttendanceTable({
                 {row.data.lname}, {row.data.fname}
               </TableCell>
 
-              {[AttendanceStatus.Present, AttendanceStatus.Absent, AttendanceStatus.NotScheduled].map(
+              {[AttendanceStatus.Here, AttendanceStatus.Absent, AttendanceStatus.NotScheduled].map(
                 (val) => (
                   <TableCell
                     key={val}
                     className={cn(
                       "w-1/3 cursor-pointer py-10 border-r",
                       !edit && "pointer-events-none opacity-50",
-                      row.data.present === val
+                      row.data.attendance_status === val
                         ? bgColorMap[val]
                         : "bg-transparent"
                     )}
                     onClick={
                       edit
-                        ? () => onPresentChange(row.data.cid, val)
+                        ? () => onStatusChange(row.data.cid, val)
                         : undefined
                     }
                   >
-                    {row.data.present === val && (
+                    {row.data.attendance_status === val && (
                       <div className="flex flex-col items-center justify-center gap-2">
-                        {val === AttendanceStatus.Present && <CheckCircle />}
+                        {val === AttendanceStatus.Here && <CheckCircle />}
                         {val === AttendanceStatus.Absent && <XCircle />}
                         {val === AttendanceStatus.NotScheduled && <PauseCircle />}
                         <span className="text-[9px] sm:text-sm">{val}</span>

--- a/server/src/services/attendance.service.ts
+++ b/server/src/services/attendance.service.ts
@@ -19,7 +19,7 @@ export async function getAttendanceService({
       clients.id AS cid,
       clients.fname,
       clients.lname,
-      attendance.present
+      attendance.attendance_status
     FROM client_roster
     JOIN clients
       ON clients.id = client_roster.cid
@@ -47,15 +47,15 @@ export async function upsertAttendanceService(
   try {
     await client.query("BEGIN");
 
-    for (const { cid, attendance_date, present } of list) {
+    for (const { cid, attendance_date, attendance_status } of list) {
       await client.query(
         `
-        INSERT INTO attendance (cid, attendance_date, present)
+        INSERT INTO attendance (cid, attendance_date, attendance_status)
         VALUES ($1, $2, $3)
         ON CONFLICT (cid, attendance_date)
-        DO UPDATE SET present = EXCLUDED.present
+        DO UPDATE SET attendance_status = EXCLUDED.attendance_status
         `,
-        [cid, attendance_date, present]
+        [cid, attendance_date, attendance_status]
       );
     }
 

--- a/server/src/validation/attendance.schema.js
+++ b/server/src/validation/attendance.schema.js
@@ -13,7 +13,7 @@ export const getAttendanceSchema = z.object({
 export const upsertAttendanceSchema = z.object({
   id: serialIdVal,
   attendance_date: dateVal,
-  present: z.boolean(),
+  attendance_status: z.string(),
 });
 
 export const upsertAttendanceArraySchema = z.array(upsertAttendanceSchema);

--- a/shared/src/validation.ts
+++ b/shared/src/validation.ts
@@ -42,7 +42,6 @@ const _ = {
     errorMap: () => ({ message: "Side is required" }),
   }),
   attendance_status: z.nativeEnum(AttendanceStatus),
-  present: z.nativeEnum(AttendanceStatus),
   status: z.nativeEnum(Status, {
     errorMap: () => ({ message: "Status is required" }),
   }),
@@ -138,7 +137,7 @@ export const attendanceSchema = z.object({
   cid: _.serialId,
   fname: _.fname,
   lname: _.lname,
-  present: _.present.nullable(),
+  attendance_status: _.attendance_status.nullable(),
 });
 export type Attendance = z.infer<typeof attendanceSchema>;
 
@@ -149,7 +148,7 @@ export const attendanceUpsertSchema = z.array(
   z.object({
     cid: _.serialId,
     attendance_date: _.date,
-    present: _.present,
+    attendance_status: _.attendance_status,
   })
 );
 export type AttendanceUpsert = z.infer<typeof attendanceUpsertSchema>;


### PR DESCRIPTION
## Summary
- rename present fields to `attendance_status`
- use correct AttendanceStatus enum on frontend

## Testing
- `npx tsc -p .` *(fails: Cannot find module 'zod' or its corresponding type declarations)*
- `npx tsc -p .` in server *(fails: Cannot find module 'dotenv')*
- `npx tsc -p tsconfig.app.json` in client *(fails: JSX runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871852c0b3083309b8e3c4c8b1cc454